### PR TITLE
Tweak compute slot behavior based on $USE_GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ RUN apt-get update && apt-get install -y wget && \
 EXPOSE 36330 7396
 
 CMD sed -i "s/{{USERNAME}}/$USERNAME/g;s/{{TEAM}}/$TEAM/g;s/{{PASSWORD}}/$PASSWORD/g;s/{{REMOTE_PASSWORD}}/$REMOTE_PASSWORD/g;s/{{POWER}}/$POWER/g;s/{{USE_GPU}}/$USE_GPU/g" /etc/fahclient/config.xml && \
+  if test "$USE_GPU" = 'false'; then sed -i "s#='GPU'/#='CPU'/#" /etc/fahclient/config.xml; fi && \
   /etc/init.d/FAHClient start && \ 
   tail -f /var/lib/fahclient/log.txt


### PR DESCRIPTION
A machine I was running this on which didn't have GPU errors out with these messages:

```
00:39:44:ERROR:HTTP_INTERNAL_SERVER_ERROR: Option 'gpu-index' has no default and is not set.
00:39:45:WARNING:149:172.17.0.1:500 HTTP INTERNAL SERVER ERROR /api/updates?_=1584837532795&sid=8c53d1d7e295f8a2218a3bac8ce7bd49: Option 'gpu-index' has no default and is not set.
```

This oneliner tweaks the compute slot of the FAH client based on $USE_GPU. Tested on two different systems, CPU only and one with a GPU.

Signed-off-by: Michael Mattsson <michael.mattsson@nimblestorage.com>